### PR TITLE
Build optimization with common phpize dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM composer:2 as composer
 FROM php:8.1-fpm-alpine as base
 
 # Git
-RUN apk add --no-cache git curl
+RUN apk add --update --no-cache git curl
 
 # Necessary build deps
-RUN apk add --update --no-cache ${PHPIZE_DEPS}
+RUN apk add --no-cache ${PHPIZE_DEPS}
 
 # ZIP module
 RUN apk add --no-cache libzip-dev && docker-php-ext-configure zip && docker-php-ext-install zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM composer:2 as composer
 FROM php:8.1-fpm-alpine as base
 
-# Git
-RUN apk add --update --no-cache git curl
-
-# Necessary build deps
-RUN apk add --no-cache ${PHPIZE_DEPS}
+# Necessary tools
+RUN apk add --update --no-cache ${PHPIZE_DEPS} git curl
 
 # ZIP module
 RUN apk add --no-cache libzip-dev && docker-php-ext-configure zip && docker-php-ext-install zip


### PR DESCRIPTION
PHPIZE deps should be installed only once to speed up the build.